### PR TITLE
Fix EZP-16874: view cache file written when cache_ttl=0 is set in tem…

### DIFF
--- a/kernel/classes/eznodeviewfunctions.php
+++ b/kernel/classes/eznodeviewfunctions.php
@@ -605,6 +605,12 @@ class eZNodeviewfunctions
             $validation
         );
 
+        // by setting cache_ttl to 0 in tpl code no cachfile should be generated
+        if ( isset( $result['no_cache'] ) and $result['no_cache'] )
+        {
+            $noCache = true;
+        }
+
         // 'store' depends on noCache: if $noCache is set, this means that retrieve
         // returned it, and the noCache fake cache file is already stored
         // and should not be stored again


### PR DESCRIPTION
Fix the issue: 
if  {set-block scope=global variable=cache_ttl}0{/set-block} is set in view full template, 
no cache file should be generated to reduce io write calls and storage size